### PR TITLE
#333: keep dnsjava's resolver provider out of the shadow jar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - Fix: smartctl, upsc, systemctl and journalctl were treated as present on any host whose `/bin/sh` is dash, so the agent kept calling tools that were not installed
 - Fix: a network interface that no longer exists is dropped instead of being polled on every refresh, which stopped a docker host filling the log with errors about the veth interfaces of removed containers
 - Fix: `openLogFileConnection` and the `tailLogFile` subscription now only read files the `logReader` configuration exposes, instead of any path they are given
+- Fix: the fat jar, the dist zip, the deb and the Windows installer no longer fail to start on the first hostname lookup
 
 ### 0.42.1
 

--- a/build.gradle
+++ b/build.gradle
@@ -185,6 +185,10 @@ task jibNativeImage(type: com.google.cloud.tools.jib.gradle.BuildImageTask) {
 
 shadowJar {
     mergeServiceFiles()
+    // dnsjava declares this provider from a class it only ships under META-INF/versions/18, which
+    // a jar without Multi-Release cannot load, so the first hostname lookup dies. The provider
+    // hands back the JDK's built-in resolver unless org.dnsjava.spi.enable is set, so it is no loss.
+    exclude 'META-INF/services/java.net.spi.InetAddressResolverProvider'
     exclude 'META-INF/*.DSA'
     exclude 'META-INF/*.RSA'
     append 'META-INF/spring.tooling'


### PR DESCRIPTION
Closes #333