### PR TITLE
#349: use the check's name in push notifications instead of its id

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+- Fix: Check push notifications show the check's name instead of its id
 - Feature: A file operation on a directory now reports real totalFiles/totalBytes once it has walked the tree, with a MEASURING state while it does, and a smoothed bytesPerSecond while it runs
 - Feature: Web server checks are now checks
   - A check has a name, can be turned off without being deleted, and runs on its own interval and timeout instead of sharing one 30 second schedule

--- a/src/main/kotlin/com/krillsson/sysapi/notifications/localization/CheckEventFormatter.kt
+++ b/src/main/kotlin/com/krillsson/sysapi/notifications/localization/CheckEventFormatter.kt
@@ -1,0 +1,41 @@
+package com.krillsson.sysapi.notifications.localization
+
+import com.krillsson.sysapi.core.check.CheckService
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class CheckEventFormatter(
+    private val checkService: CheckService,
+) {
+    fun formatWebServerUpOngoingDescription(monitoredItemId: String?): String =
+        "${displayName(monitoredItemId)} is failing its check"
+
+    fun formatCheckLatencyOngoingDescription(
+        monitoredItemId: String?,
+        formattedValue: String,
+        formattedThreshold: String,
+    ): String =
+        "${displayName(monitoredItemId)} answered in $formattedValue, above $formattedThreshold"
+
+    fun formatWebServerUpResolvedDescription(
+        monitoredItemId: String?,
+        formattedDuration: String,
+    ): String =
+        "${displayName(monitoredItemId)} is passing its check again after $formattedDuration"
+
+    fun formatCheckLatencyResolvedDescription(
+        monitoredItemId: String?,
+        formattedThreshold: String,
+        formattedValue: String,
+        formattedDuration: String,
+    ): String =
+        "${displayName(monitoredItemId)} is back below $formattedThreshold at $formattedValue after $formattedDuration"
+
+    private fun displayName(monitoredItemId: String?): String? =
+        monitoredItemId
+            ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+            ?.let { checkService.getById(it) }
+            ?.name
+            ?: monitoredItemId
+}

--- a/src/main/kotlin/com/krillsson/sysapi/notifications/localization/OngoingEventFormatter.kt
+++ b/src/main/kotlin/com/krillsson/sysapi/notifications/localization/OngoingEventFormatter.kt
@@ -1,23 +1,14 @@
 package com.krillsson.sysapi.notifications.localization
 
-import com.krillsson.sysapi.core.check.CheckService
 import com.krillsson.sysapi.core.monitoring.Monitor
 import com.krillsson.sysapi.notifications.Notification
 import org.springframework.stereotype.Component
-import java.util.UUID
 
 @Component
 class OngoingEventFormatter(
     private val monitoredValueFormatter: MonitoredValueFormatter,
-    private val checkService: CheckService,
+    private val checkEventFormatter: CheckEventFormatter,
 ) {
-
-    private fun checkDisplayName(monitoredItemId: String?): String? =
-        monitoredItemId
-            ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
-            ?.let { checkService.getById(it) }
-            ?.name
-            ?: monitoredItemId
     fun formatOngoingEventTitle(
         notification: Notification.OngoingEvent,
         serverName: String,
@@ -108,8 +99,12 @@ class OngoingEventFormatter(
                     )
                 } CPU usage went above $formattedThreshold to $formattedValue"
 
-                Monitor.Type.WEBSERVER_UP -> "${checkDisplayName(monitoredItemId)} is failing its check"
-                Monitor.Type.CHECK_LATENCY -> "${checkDisplayName(monitoredItemId)} answered in $formattedValue, above $formattedThreshold"
+                Monitor.Type.WEBSERVER_UP -> checkEventFormatter.formatWebServerUpOngoingDescription(monitoredItemId)
+                Monitor.Type.CHECK_LATENCY -> checkEventFormatter.formatCheckLatencyOngoingDescription(
+                    monitoredItemId,
+                    formattedValue,
+                    formattedThreshold
+                )
                 Monitor.Type.DISK_TEMPERATURE -> "Temperature on $monitoredItemId went above $formattedThreshold to $formattedValue"
                 Monitor.Type.UPS_OPERATING_NORMALLY -> "UPS $monitoredItemId is not operating normally"
                 Monitor.Type.UPS_LOAD_PERCENTAGE -> "UPS $monitoredItemId load went above $formattedThreshold to $formattedValue"

--- a/src/main/kotlin/com/krillsson/sysapi/notifications/localization/OngoingEventFormatter.kt
+++ b/src/main/kotlin/com/krillsson/sysapi/notifications/localization/OngoingEventFormatter.kt
@@ -1,13 +1,23 @@
 package com.krillsson.sysapi.notifications.localization
 
+import com.krillsson.sysapi.core.check.CheckService
 import com.krillsson.sysapi.core.monitoring.Monitor
 import com.krillsson.sysapi.notifications.Notification
 import org.springframework.stereotype.Component
+import java.util.UUID
 
 @Component
 class OngoingEventFormatter(
     private val monitoredValueFormatter: MonitoredValueFormatter,
+    private val checkService: CheckService,
 ) {
+
+    private fun checkDisplayName(monitoredItemId: String?): String? =
+        monitoredItemId
+            ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+            ?.let { checkService.getById(it) }
+            ?.name
+            ?: monitoredItemId
     fun formatOngoingEventTitle(
         notification: Notification.OngoingEvent,
         serverName: String,
@@ -98,8 +108,8 @@ class OngoingEventFormatter(
                     )
                 } CPU usage went above $formattedThreshold to $formattedValue"
 
-                Monitor.Type.WEBSERVER_UP -> "$monitoredItemId is failing its check"
-                Monitor.Type.CHECK_LATENCY -> "$monitoredItemId answered in $formattedValue, above $formattedThreshold"
+                Monitor.Type.WEBSERVER_UP -> "${checkDisplayName(monitoredItemId)} is failing its check"
+                Monitor.Type.CHECK_LATENCY -> "${checkDisplayName(monitoredItemId)} answered in $formattedValue, above $formattedThreshold"
                 Monitor.Type.DISK_TEMPERATURE -> "Temperature on $monitoredItemId went above $formattedThreshold to $formattedValue"
                 Monitor.Type.UPS_OPERATING_NORMALLY -> "UPS $monitoredItemId is not operating normally"
                 Monitor.Type.UPS_LOAD_PERCENTAGE -> "UPS $monitoredItemId load went above $formattedThreshold to $formattedValue"

--- a/src/main/kotlin/com/krillsson/sysapi/notifications/localization/ResolvedEventFormatter.kt
+++ b/src/main/kotlin/com/krillsson/sysapi/notifications/localization/ResolvedEventFormatter.kt
@@ -1,15 +1,25 @@
 package com.krillsson.sysapi.notifications.localization
 
+import com.krillsson.sysapi.core.check.CheckService
 import com.krillsson.sysapi.core.monitoring.Monitor
 import com.krillsson.sysapi.notifications.Notification
 import org.springframework.stereotype.Component
 import java.time.Duration
+import java.util.UUID
 
 @Component
 class ResolvedEventFormatter(
     private val monitoredValueFormatter: MonitoredValueFormatter,
     private val durationFormatter: DurationFormatter,
+    private val checkService: CheckService,
 ) {
+
+    private fun checkDisplayName(monitoredItemId: String?): String? =
+        monitoredItemId
+            ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+            ?.let { checkService.getById(it) }
+            ?.name
+            ?: monitoredItemId
     fun formatResolvedEventTitle(
         notification: Notification.ResolvedEvent,
         serverName: String,
@@ -102,8 +112,8 @@ class ResolvedEventFormatter(
                     )
                 } CPU usage is back below $formattedThreshold at $formattedValue after $formattedDuration"
 
-                Monitor.Type.WEBSERVER_UP -> "$monitoredItemId is passing its check again after $formattedDuration"
-                Monitor.Type.CHECK_LATENCY -> "$monitoredItemId is back below $formattedThreshold at $formattedValue after $formattedDuration"
+                Monitor.Type.WEBSERVER_UP -> "${checkDisplayName(monitoredItemId)} is passing its check again after $formattedDuration"
+                Monitor.Type.CHECK_LATENCY -> "${checkDisplayName(monitoredItemId)} is back below $formattedThreshold at $formattedValue after $formattedDuration"
                 Monitor.Type.DISK_TEMPERATURE -> "Temperature on $monitoredItemId is back below $formattedThreshold at $formattedValue after $formattedDuration"
                 Monitor.Type.UPS_OPERATING_NORMALLY -> "UPS $monitoredItemId is operating normally again after $formattedDuration"
                 Monitor.Type.UPS_LOAD_PERCENTAGE -> "UPS $monitoredItemId load is back below $formattedThreshold at $formattedValue after $formattedDuration"

--- a/src/main/kotlin/com/krillsson/sysapi/notifications/localization/ResolvedEventFormatter.kt
+++ b/src/main/kotlin/com/krillsson/sysapi/notifications/localization/ResolvedEventFormatter.kt
@@ -1,25 +1,16 @@
 package com.krillsson.sysapi.notifications.localization
 
-import com.krillsson.sysapi.core.check.CheckService
 import com.krillsson.sysapi.core.monitoring.Monitor
 import com.krillsson.sysapi.notifications.Notification
 import org.springframework.stereotype.Component
 import java.time.Duration
-import java.util.UUID
 
 @Component
 class ResolvedEventFormatter(
     private val monitoredValueFormatter: MonitoredValueFormatter,
     private val durationFormatter: DurationFormatter,
-    private val checkService: CheckService,
+    private val checkEventFormatter: CheckEventFormatter,
 ) {
-
-    private fun checkDisplayName(monitoredItemId: String?): String? =
-        monitoredItemId
-            ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
-            ?.let { checkService.getById(it) }
-            ?.name
-            ?: monitoredItemId
     fun formatResolvedEventTitle(
         notification: Notification.ResolvedEvent,
         serverName: String,
@@ -112,8 +103,17 @@ class ResolvedEventFormatter(
                     )
                 } CPU usage is back below $formattedThreshold at $formattedValue after $formattedDuration"
 
-                Monitor.Type.WEBSERVER_UP -> "${checkDisplayName(monitoredItemId)} is passing its check again after $formattedDuration"
-                Monitor.Type.CHECK_LATENCY -> "${checkDisplayName(monitoredItemId)} is back below $formattedThreshold at $formattedValue after $formattedDuration"
+                Monitor.Type.WEBSERVER_UP -> checkEventFormatter.formatWebServerUpResolvedDescription(
+                    monitoredItemId,
+                    formattedDuration
+                )
+
+                Monitor.Type.CHECK_LATENCY -> checkEventFormatter.formatCheckLatencyResolvedDescription(
+                    monitoredItemId,
+                    formattedThreshold,
+                    formattedValue,
+                    formattedDuration
+                )
                 Monitor.Type.DISK_TEMPERATURE -> "Temperature on $monitoredItemId is back below $formattedThreshold at $formattedValue after $formattedDuration"
                 Monitor.Type.UPS_OPERATING_NORMALLY -> "UPS $monitoredItemId is operating normally again after $formattedDuration"
                 Monitor.Type.UPS_LOAD_PERCENTAGE -> "UPS $monitoredItemId load is back below $formattedThreshold at $formattedValue after $formattedDuration"

--- a/src/test/kotlin/com/krillsson/sysapi/notifications/localization/CheckEventFormatterTest.kt
+++ b/src/test/kotlin/com/krillsson/sysapi/notifications/localization/CheckEventFormatterTest.kt
@@ -1,0 +1,85 @@
+package com.krillsson.sysapi.notifications.localization
+
+import com.krillsson.sysapi.core.check.CheckService
+import com.krillsson.sysapi.core.check.HttpCheck
+import com.krillsson.sysapi.core.check.HttpMethod
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class CheckEventFormatterTest {
+
+    private val checkService: CheckService = mockk()
+    private val formatter = CheckEventFormatter(checkService)
+
+    private val checkId: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555")
+
+    private fun httpCheck(name: String) = HttpCheck(
+        id = checkId,
+        name = name,
+        enabled = true,
+        intervalSeconds = 60,
+        timeoutSeconds = 20,
+        url = "https://example.com",
+        method = HttpMethod.GET,
+        expectedStatusCodes = "200-299",
+        keyword = null,
+        keywordInverted = false,
+        ignoreCertificateErrors = false,
+        followRedirects = true,
+        headers = emptyList()
+    )
+
+    @Test
+    fun `uses the check's name when it can still be resolved`() {
+        // Given
+        every { checkService.getById(checkId) } returns httpCheck("example.com")
+
+        // When
+        val ongoing = formatter.formatWebServerUpOngoingDescription(checkId.toString())
+        val resolved = formatter.formatWebServerUpResolvedDescription(checkId.toString(), "5 minutes")
+
+        // Then
+        ongoing shouldBe "example.com is failing its check"
+        resolved shouldBe "example.com is passing its check again after 5 minutes"
+    }
+
+    @Test
+    fun `falls back to the raw monitored item id when the check can no longer be resolved`() {
+        // Given
+        every { checkService.getById(checkId) } returns null
+
+        // When
+        val ongoing = formatter.formatWebServerUpOngoingDescription(checkId.toString())
+        val resolved = formatter.formatWebServerUpResolvedDescription(checkId.toString(), "5 minutes")
+
+        // Then
+        ongoing shouldBe "$checkId is failing its check"
+        resolved shouldBe "$checkId is passing its check again after 5 minutes"
+    }
+
+    @Test
+    fun `falls back to the raw monitored item id when it is not a valid check id`() {
+        // When
+        val ongoing = formatter.formatWebServerUpOngoingDescription("not-a-uuid")
+
+        // Then
+        ongoing shouldBe "not-a-uuid is failing its check"
+    }
+
+    @Test
+    fun `formats check latency descriptions with the resolved name`() {
+        // Given
+        every { checkService.getById(checkId) } returns httpCheck("example.com")
+
+        // When
+        val ongoing = formatter.formatCheckLatencyOngoingDescription(checkId.toString(), "500ms", "300ms")
+        val resolved = formatter.formatCheckLatencyResolvedDescription(checkId.toString(), "300ms", "150ms", "5 minutes")
+
+        // Then
+        ongoing shouldBe "example.com answered in 500ms, above 300ms"
+        resolved shouldBe "example.com is back below 300ms at 150ms after 5 minutes"
+    }
+}

--- a/src/test/kotlin/com/krillsson/sysapi/notifications/localization/OngoingEventFormatterTest.kt
+++ b/src/test/kotlin/com/krillsson/sysapi/notifications/localization/OngoingEventFormatterTest.kt
@@ -1,7 +1,6 @@
 package com.krillsson.sysapi.notifications.localization
 
 import com.krillsson.sysapi.core.check.CheckService
-import com.krillsson.sysapi.core.check.CheckType
 import com.krillsson.sysapi.core.check.HttpCheck
 import com.krillsson.sysapi.core.check.HttpMethod
 import com.krillsson.sysapi.core.monitoring.Monitor
@@ -18,7 +17,10 @@ import java.util.UUID
 class OngoingEventFormatterTest {
 
     private val checkService: CheckService = mockk()
-    private val formatter = OngoingEventFormatter(MonitoredValueFormatter(mockk(), mockk()), checkService)
+    private val formatter = OngoingEventFormatter(
+        MonitoredValueFormatter(mockk(), mockk()),
+        CheckEventFormatter(checkService)
+    )
 
     private val checkId: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555")
 
@@ -34,7 +36,7 @@ class OngoingEventFormatterTest {
     )
 
     @Test
-    fun `uses the check's name in the description when it can still be resolved`() {
+    fun `delegates the webserver up description to the check event formatter`() {
         // Given
         every { checkService.getById(checkId) } returns HttpCheck(
             id = checkId,
@@ -57,17 +59,5 @@ class OngoingEventFormatterTest {
 
         // Then
         description shouldBe "example.com is failing its check"
-    }
-
-    @Test
-    fun `falls back to the raw monitored item id when the check can no longer be resolved`() {
-        // Given
-        every { checkService.getById(checkId) } returns null
-
-        // When
-        val description = formatter.formatOngoingEventDescription(ongoingEvent(checkId.toString()))
-
-        // Then
-        description shouldBe "$checkId is failing its check"
     }
 }

--- a/src/test/kotlin/com/krillsson/sysapi/notifications/localization/OngoingEventFormatterTest.kt
+++ b/src/test/kotlin/com/krillsson/sysapi/notifications/localization/OngoingEventFormatterTest.kt
@@ -1,0 +1,73 @@
+package com.krillsson.sysapi.notifications.localization
+
+import com.krillsson.sysapi.core.check.CheckService
+import com.krillsson.sysapi.core.check.CheckType
+import com.krillsson.sysapi.core.check.HttpCheck
+import com.krillsson.sysapi.core.check.HttpMethod
+import com.krillsson.sysapi.core.monitoring.Monitor
+import com.krillsson.sysapi.core.monitoring.MonitoredValue
+import com.krillsson.sysapi.notifications.Notification
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+class OngoingEventFormatterTest {
+
+    private val checkService: CheckService = mockk()
+    private val formatter = OngoingEventFormatter(MonitoredValueFormatter(mockk(), mockk()), checkService)
+
+    private val checkId: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555")
+
+    private fun ongoingEvent(monitoredItemId: String?) = Notification.OngoingEvent(
+        id = UUID.randomUUID(),
+        monitorId = UUID.randomUUID(),
+        monitoredItemId = monitoredItemId,
+        monitorType = Monitor.Type.WEBSERVER_UP,
+        startTime = Instant.now(),
+        threshold = MonitoredValue.ConditionalValue(true),
+        value = MonitoredValue.ConditionalValue(false),
+        inertia = Duration.ZERO
+    )
+
+    @Test
+    fun `uses the check's name in the description when it can still be resolved`() {
+        // Given
+        every { checkService.getById(checkId) } returns HttpCheck(
+            id = checkId,
+            name = "example.com",
+            enabled = true,
+            intervalSeconds = 60,
+            timeoutSeconds = 20,
+            url = "https://example.com",
+            method = HttpMethod.GET,
+            expectedStatusCodes = "200-299",
+            keyword = null,
+            keywordInverted = false,
+            ignoreCertificateErrors = false,
+            followRedirects = true,
+            headers = emptyList()
+        )
+
+        // When
+        val description = formatter.formatOngoingEventDescription(ongoingEvent(checkId.toString()))
+
+        // Then
+        description shouldBe "example.com is failing its check"
+    }
+
+    @Test
+    fun `falls back to the raw monitored item id when the check can no longer be resolved`() {
+        // Given
+        every { checkService.getById(checkId) } returns null
+
+        // When
+        val description = formatter.formatOngoingEventDescription(ongoingEvent(checkId.toString()))
+
+        // Then
+        description shouldBe "$checkId is failing its check"
+    }
+}

--- a/src/test/kotlin/com/krillsson/sysapi/notifications/localization/ResolvedEventFormatterTest.kt
+++ b/src/test/kotlin/com/krillsson/sysapi/notifications/localization/ResolvedEventFormatterTest.kt
@@ -18,7 +18,7 @@ class ResolvedEventFormatterTest {
     private val formatter = ResolvedEventFormatter(
         MonitoredValueFormatter(mockk(), mockk()),
         DurationFormatter(),
-        checkService
+        CheckEventFormatter(checkService)
     )
 
     private val checkId: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555")
@@ -36,7 +36,7 @@ class ResolvedEventFormatterTest {
     )
 
     @Test
-    fun `uses the check's name in the description when it can still be resolved`() {
+    fun `delegates the webserver up description to the check event formatter`() {
         // Given
         every { checkService.getById(checkId) } returns TcpCheck(
             id = checkId,
@@ -53,17 +53,5 @@ class ResolvedEventFormatterTest {
 
         // Then
         description shouldBe "nas.lan is passing its check again after 5 minutes"
-    }
-
-    @Test
-    fun `falls back to the raw monitored item id when the check can no longer be resolved`() {
-        // Given
-        every { checkService.getById(checkId) } returns null
-
-        // When
-        val description = formatter.formatResolvedEventDescription(resolvedEvent(checkId.toString()))
-
-        // Then
-        description shouldBe "$checkId is passing its check again after 5 minutes"
     }
 }

--- a/src/test/kotlin/com/krillsson/sysapi/notifications/localization/ResolvedEventFormatterTest.kt
+++ b/src/test/kotlin/com/krillsson/sysapi/notifications/localization/ResolvedEventFormatterTest.kt
@@ -1,0 +1,69 @@
+package com.krillsson.sysapi.notifications.localization
+
+import com.krillsson.sysapi.core.check.CheckService
+import com.krillsson.sysapi.core.check.TcpCheck
+import com.krillsson.sysapi.core.monitoring.Monitor
+import com.krillsson.sysapi.core.monitoring.MonitoredValue
+import com.krillsson.sysapi.notifications.Notification
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class ResolvedEventFormatterTest {
+
+    private val checkService: CheckService = mockk()
+    private val formatter = ResolvedEventFormatter(
+        MonitoredValueFormatter(mockk(), mockk()),
+        DurationFormatter(),
+        checkService
+    )
+
+    private val checkId: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555")
+
+    private fun resolvedEvent(monitoredItemId: String?) = Notification.ResolvedEvent(
+        id = UUID.randomUUID(),
+        monitorId = UUID.randomUUID(),
+        monitoredItemId = monitoredItemId,
+        monitorType = Monitor.Type.WEBSERVER_UP,
+        startTime = Instant.parse("2026-08-18T10:00:00Z"),
+        endTime = Instant.parse("2026-08-18T10:05:00Z"),
+        threshold = MonitoredValue.ConditionalValue(true),
+        startValue = MonitoredValue.ConditionalValue(false),
+        endValue = MonitoredValue.ConditionalValue(true)
+    )
+
+    @Test
+    fun `uses the check's name in the description when it can still be resolved`() {
+        // Given
+        every { checkService.getById(checkId) } returns TcpCheck(
+            id = checkId,
+            name = "nas.lan",
+            enabled = true,
+            intervalSeconds = 60,
+            timeoutSeconds = 20,
+            host = "nas.lan",
+            port = 445
+        )
+
+        // When
+        val description = formatter.formatResolvedEventDescription(resolvedEvent(checkId.toString()))
+
+        // Then
+        description shouldBe "nas.lan is passing its check again after 5 minutes"
+    }
+
+    @Test
+    fun `falls back to the raw monitored item id when the check can no longer be resolved`() {
+        // Given
+        every { checkService.getById(checkId) } returns null
+
+        // When
+        val description = formatter.formatResolvedEventDescription(resolvedEvent(checkId.toString()))
+
+        // Then
+        description shouldBe "$checkId is passing its check again after 5 minutes"
+    }
+}


### PR DESCRIPTION
Closes #349