### PR TITLE
#361: disable the async request timeout so file downloads aren't cut off mid-stream

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+- Fix: File downloads no longer stall after 30 seconds regardless of transfer progress.
+
 ### 0.44.0
 
 - Updates to container updates:

--- a/config/application.properties
+++ b/config/application.properties
@@ -26,6 +26,8 @@ spring.datasource.max-active=1
 spring.datasource.hikari.maximum-pool-size=1
 spring.task.scheduling.pool.size=5
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+# file downloads stream for as long as the transfer takes, not capped by wall-clock time
+spring.mvc.async.request-timeout=-1
 # docker java client fixes
 spring.jackson.mapper.ACCEPT_CASE_INSENSITIVE_ENUMS=true
 spring.jackson.mapper.ACCEPT_CASE_INSENSITIVE_PROPERTIES=true


### PR DESCRIPTION
Closes #361